### PR TITLE
Add :component-key to ex-info of try-action

### DIFF
--- a/src/com/stuartsierra/component.clj
+++ b/src/com/stuartsierra/component.clj
@@ -103,6 +103,7 @@
                          {:reason ::component-function-threw-exception
                           :function f
                           :component component
+                          :component-key key
                           :system system}
                          t)))))
 


### PR DESCRIPTION
This way the component key can be used in the exception handling logic when starting, stopping, or otherwise updating a system.
