### PR TITLE
Dissoc sub-components when shutting down a system

### DIFF
--- a/src/com/stuartsierra/component.clj
+++ b/src/com/stuartsierra/component.clj
@@ -94,6 +94,9 @@
              component
              (dependencies component)))
 
+(defn- dissoc-dependencies [component]
+  (reduce-kv #(dissoc %1 %3) component (dependencies component)))
+
 (defn- try-action [component system key f args]
   (try (apply f component args)
        (catch Throwable t
@@ -134,8 +137,8 @@
     (reduce (fn [system key]
               (assoc system key
                      (-> (get-component system key)
-                         (assoc-dependencies system)
-                         (try-action system key f args))))
+                         (try-action system key f args)
+                         (dissoc-dependencies))))
             system
             (reverse (sort (dep/topo-comparator graph) component-keys)))))
 


### PR DESCRIPTION
Hey Stuart,

when developing components/systems with your library I usually
make sure that components are idempotent. In the start function I
usually assoc onto the component, and in the stop function I do
cleanup. Like in the following component:

```
(defrecord ComponentF [state]
  component/Lifecycle
  (start [this]
    (log 'ComponentF.start this)
    (assoc this ::started? true))
  (stop [this]
    (log 'ComponentF.stop this)
    (dissoc this ::started?)))

(defn component-f []
  (->ComponentF (rand-int Integer/MAX_VALUE)))
```

Then I usually write tests like this to make sure my system
doesn't break when starting/stopping it multiple times. So
starting an already started system should return the already
started one, and for stopping vice versa.

Given a system that I start and then stop, I would expect to get
the same system back as the one I passed to the `start`
function. At the moment this is not true, because the sub
components are not dissoced from the stopped system.

```
(deftest test-idempotence
  (let [system (-> (component/system-map
                    :f-1 (component-f)
                    :f-2 (component-f)
                    :f-3 (component-f))
                   (component/system-using
                    {:f-3 [:f-1 :f-2]}))
        started (component/start system)]
    (is (= started (component/start system)))
    (let [stopped (component/stop started)]
      (is (= system stopped))
      (is (= stopped (component/stop stopped))))))
```

I think this is the right/expected behaviour. What do you think?
This pull request addresses this problem and dissoces the sub
components after stopping them.

Would you like to merge this? And if so, I would be happy about a
new release. Otherwise this is a great library!

Thanks, Roman.
