### PR TITLE
add system and key component to try-action function scope

### DIFF
--- a/src/com/stuartsierra/component.clj
+++ b/src/com/stuartsierra/component.clj
@@ -95,7 +95,7 @@
              (dependencies component)))
 
 (defn- try-action [component system key f args]
-  (try (apply f component args)
+  (try (apply f component (when args (with-meta args {::system system ::key key})))
        (catch Throwable t
          (throw (ex-info (str "Error in component " key
                               " in system " (.getName (class system))


### PR DESCRIPTION
As you can see following this trick the action could access to its component name and full system
In my case I need it for AOP purposes (system visualisations and sequence diagram visualisations)
