### PR TITLE
Fix quoting in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ For development, I might create a `user` namespace like this:
 
 (defn reset []
   (stop)
-  (refresh :after 'user/go))
+  (refresh :after `user/go))
 ```
 
 


### PR DESCRIPTION
Backtick should be used for `after` hook in `refresh` of `clojure.tools.namespace`, since it requires a namespace-qualified symbol.

This may spare someone a couple of minutes.