### PR TITLE
Destructured using

### DIFF
--- a/src/com/stuartsierra/component.clj
+++ b/src/com/stuartsierra/component.clj
@@ -24,7 +24,7 @@
   [component]
   (::dependencies (meta component) {}))
 
-(defn using
+(defn using*
   "Associates metadata with component describing the other components
   on which it depends. Component dependencies are specified as a map.
   Keys in the map correspond to keys in this component which must be
@@ -40,11 +40,21 @@
       dependencies
     (vector? dependencies)
       (into {} (map (fn [x] [x x]) dependencies))
+
     :else
       (throw (ex-info "Dependencies must be a map or vector"
                       {:reason ::invalid-dependencies
                        :component component
                        :dependencies dependencies})))))
+
+(defmacro using
+  "Like using*, but instead of simple renaming of dependencies for a map,
+   allow complex destructuring."
+  [component dependencies]
+  `(using* ~component
+           ~(if (map? dependencies)
+              `(quote ~dependencies)
+              dependencies)))
 
 (defn- nil-component [system key]
   (ex-info (str "Component " key " was nil in system; maybe it returned nil from start or stop")
@@ -103,9 +113,42 @@
              (dep/graph)
              (select-keys system component-keys)))
 
-(defn- assoc-dependency [system component dependency-key system-key]
-  (let [dependency (get-dependency system system-key component dependency-key)]
-    (assoc component dependency-key dependency)))
+
+(defn- find-user-symbols-in-destructured-bindings
+  [bindings]
+  (let [blacklist ["map__" "vec__"]
+        m (apply hash-map bindings)
+        pred (fn [[s _]] (boolean (some #(.startsWith (str s) %) blacklist)))]
+    (remove pred m)))
+
+(defn- extract-assoc-lookups-from-destructured-bindings
+  [bindings]
+  (some->> (find-user-symbols-in-destructured-bindings bindings)
+           (map (fn [[k v]] [(keyword k) k]))
+           (into {})))
+
+(defmacro destructure-dependency
+  [dependency bindings]
+  `(let [bindings# (destructure [~bindings ~dependency])
+         dep-lookups# (extract-assoc-lookups-from-destructured-bindings bindings#)]
+     [bindings# dep-lookups#]))
+
+(defmacro manual-let
+  [bindings & body]
+  (cons 'let*
+        (list (apply vector bindings)
+              (cons 'do body))))
+
+(defn- assoc-dependency [system component dependency-bindings system-key]
+  (let [dependency (get-dependency system system-key component dependency-bindings)]
+    (if (keyword? dependency-bindings)
+      ;; old path, this is at most a renaming
+      (assoc component dependency-bindings dependency)
+      ;; destructure the dependency-bindings
+      (let [[bindings dep-lookups] (destructure-dependency dependency dependency-bindings)]
+        (assoc component
+               (ffirst dep-lookups)
+               (eval `(manual-let ~bindings (second (first ~dep-lookups)))))))))
 
 (defn- assoc-dependencies [component system]
   (reduce-kv #(assoc-dependency system %1 %2 %3)

--- a/test/com/stuartsierra/component_test.clj
+++ b/test/com/stuartsierra/component_test.clj
@@ -291,12 +291,18 @@
 
 (defrecord FooBazComponent [foo baz spam])
 
+(def du-system
+  {:settings {:foo :foo :bar :bar}
+   :other-settings {:spam :eggs}
+   :foo-baz (component/using (map->FooBazComponent {})
+                             {{baz :bar} :settings
+                              {:keys [spam]} :other-settings})})
+
+(def du-system-map
+  (apply component/system-map (apply concat du-system)))
+
 (deftest destructured-using
-  (let [s (component/system-map :settings {:foo :foo :bar :bar}
-                                :other-settings {:spam :eggs}
-                                :foo-baz (component/using (->FooBazComponent)
-                                                          {{baz :bar} :settings
-                                                           {:keys [spam]} :other-settings}))
+  (let [s du-system-map
         ss (component/start s)]
     (is (= :bar (get-in ss [:foo-baz :baz])))
     (is (= :eggs (get-in ss [:foo-baz :spam])))))

--- a/test/com/stuartsierra/component_test.clj
+++ b/test/com/stuartsierra/component_test.clj
@@ -288,3 +288,15 @@
                false
                (catch Exception e e))]
     (is (= ::component/nil-component (:reason (ex-data e))))))
+
+(defrecord FooBazComponent [foo baz spam])
+
+(deftest destructured-using
+  (let [s (component/system-map :settings {:foo :foo :bar :bar}
+                                :other-settings {:spam :eggs}
+                                :foo-baz (component/using (->FooBazComponent)
+                                                          {{baz :bar} :settings
+                                                           {:keys [spam]} :other-settings}))
+        ss (component/start s)]
+    (is (= :bar (get-in ss [:foo-baz :baz])))
+    (is (= :eggs (get-in ss [:foo-baz :spam])))))


### PR DESCRIPTION
This allows the left hand side of the using dependency map to be processed by `clojure.core/destructure`. This is useful for decoupling settings (maybe delivered via environ, zookeeper, or a json file) into their own component, which other components can depend on and destructure however makes sense for the component.