### PR TITLE
Difficulty starting just a piece of a system

### DIFF
--- a/src/com/stuartsierra/component.cljc
+++ b/src/com/stuartsierra/component.cljc
@@ -133,8 +133,12 @@
              (try-action system key f args))))
 
 (defn- dependency-order [system component-keys]
-  (let [graph (dependency-graph system component-keys)]
-    (sort (dep/topo-comparator graph) component-keys)))
+  (let [graph (dependency-graph system component-keys)
+        ; include dependencies of requested components
+        ; as well as those without any dependencies
+        nodes (clojure.set/union (dep/nodes graph)
+                                 (set component-keys))]
+    (sort (dep/topo-comparator graph) nodes)))
 
 (defn update-system
   "Invokes (apply f component args) on each of the components at

--- a/src/com/stuartsierra/component.cljc
+++ b/src/com/stuartsierra/component.cljc
@@ -126,31 +126,31 @@
                           :system system}
                          t)))))
 
+(defn- update-system-key [system key f args]
+  (assoc system key
+         (-> (get-component system key)
+             (assoc-dependencies system)
+             (try-action system key f args))))
+
+(defn- dependency-order [system component-keys]
+  (let [graph (dependency-graph system component-keys)]
+    (sort (dep/topo-comparator graph) component-keys)))
+
 (defn update-system
   "Invokes (apply f component args) on each of the components at
   component-keys in the system, in dependency order. Before invoking
   f, assoc's updated dependencies of the component."
   [system component-keys f & args]
-  (let [graph (dependency-graph system component-keys)]
-    (reduce (fn [system key]
-              (assoc system key
-                     (-> (get-component system key)
-                         (assoc-dependencies system)
-                         (try-action system key f args))))
-            system
-            (sort (dep/topo-comparator graph) component-keys))))
+  (reduce #(update-system-key %1 %2 f args)
+          system
+          (dependency-order system component-keys)))
 
 (defn update-system-reverse
   "Like update-system but operates in reverse dependency order."
   [system component-keys f & args]
-  (let [graph (dependency-graph system component-keys)]
-    (reduce (fn [system key]
-              (assoc system key
-                     (-> (get-component system key)
-                         (assoc-dependencies system)
-                         (try-action system key f args))))
-            system
-            (reverse (sort (dep/topo-comparator graph) component-keys)))))
+  (reduce #(update-system-key %1 %2 f args)
+          system
+          (reverse (dependency-order system component-keys))))
 
 (defn start-system
   "Recursively starts components in the system, in dependency order,

--- a/test/com/stuartsierra/component_test.clj
+++ b/test/com/stuartsierra/component_test.clj
@@ -228,6 +228,22 @@
   (let [system (component/start (system-2))]
     (is (started? (get-in system [:beta :one :d :my-c])))))
 
+(defn system-3 []
+  (component/system-map :b1 (component-b)
+                        :b2 (component-b)
+                        :a  (component-a)))
+
+(deftest some-components-started
+  (let [system (component/start-system (system-3) #{:b1})]
+    (is (started? (:b1 system)))
+    (is (started? (:a system)))
+    (is (not (started? (:b2 system))))))
+
+(deftest some-dependencies-satisfied
+  (let [system (component/start-system (system-3) #{:b1})]
+    (is (started? (get-in system [:b1 :a])))
+    (is (nil? (get-in system [:b2 :a])))))
+
 (defn increment-all-components [system]
   (component/update-system
    system (keys system) update-in [:n] inc))


### PR DESCRIPTION
I have a system with dependencies like this:

```
  web-server ----> logger
             \---> business-logic ---> db
  migrations ------^
```

I'd like to be able to easily start the `migrations` part of this system.

That is, I'd like a started system such that:
 1. the `web-server` and `logger` are not running, but
 2. `migrations` and its direct and transitive dependencies (`business-logic` and `db`) are started and wired together.

This is useful in scenarios like migrations, when you want one-off processes that have access to the business logic, but do not try to listen to any web traffic.  Or when you have two types of input, say a web server and a message queue, and you want to run them in separate processes.

What's the recommended way of doing this?  In a simple example like this, it's easy enough to dissoc the `web-server` before starting the system.  But it's not obvious that `logger` could also be dissoc'ed.  In a more complex system it's hard to know what else can be trimmed out when a few components are removed.

Is it best-practice to have helper functions that create different systems?  That seems like it could lead to duplication and manual tracking of dependencies.

I originally expected that the two-argument version of `component/start-system` was designed for this, e.g. `(component/start-system sys #{:migrations})`.  But this creates a broken system, with the dependencies associated but not started. To have them be started, they all need to be included in the second argument, like `(component/start-system sys #{:migrations :business-logic :db})`.  That is, to get a fully started partial system, you must manually maintain a list of all nodes in the dependency graph starting from the desired top-level components.

This seems like a bug in `component/start-system`, although I imagine it would be hard to change its API at this point.  If you do think it's OK to change, please consider this pull request as a starting point.

This pull request makes `(component/start-system sys #{:migrations})` behave as I expected it did: it assocs *and* starts dependencies.  There are new tests to demonstrate its behavior.  However one of the old tests about `missing-dependency-error` fails.  Now, when you have a component that depends on a another component that isn't in the system, you get a `missing-component` error, instead of the `missing-dependency` error you used to get.  I haven't tested it extensively, but it may no longer be possible to get `missing-dependency` errors, because `get-component` will be called on the dependency before `get-dependency` ever is.

If you are interested in merging this, let me know how you'd like to deal with the failing test.  Also note that this builds on a prior pull request I submitted, #42.  If you'd like, I can look into separating the two.