### PR TITLE
Teardown when exception on start + predicate fns

### DIFF
--- a/src/com/stuartsierra/component.cljc
+++ b/src/com/stuartsierra/component.cljc
@@ -152,15 +152,47 @@
             system
             (reverse (sort (dep/topo-comparator graph) component-keys)))))
 
+(defn- start-with-pred
+  "Starts a component and associates a started? key if it
+   successfully starts."
+  [component]
+  (-> component start (assoc :started? true)))
+
+(defn- stop-with-pred
+  "Stops a component and dissasociates a started? key if it
+   successfully stops."
+  [component]
+  (-> component stop (assoc :started? false)))
+
+(defn started?
+  "Determines if the component is in a started state."
+  [component]
+  (boolean (:started? component)))
+
+(defn stopped?
+  "Determines if the given component is in a stopped state."
+  [component]
+  (not (started? component)))
+
 (defn start-system
   "Recursively starts components in the system, in dependency order,
   assoc'ing in their dependencies along the way. component-keys is a
   collection of keys (order doesn't matter) in the system specifying
-  the components to start, defaults to all keys in the system."
+  the components to start, defaults to all keys in the system. If
+  an exception is thrown, it'll tear down the system and ensure any
+  components that were started are stopped."
   ([system]
      (start-system system (keys system)))
   ([system component-keys]
-     (update-system system component-keys #'start)))
+   (try
+     (update-system system component-keys start-with-pred)
+     (catch Throwable e
+       (let [thrown-system (-> e ex-data :system)
+             started-keys (->> thrown-system
+                               (filter (fn [[k v]] (started? v)))
+                               (keys))]
+         (update-system-reverse system started-keys stop-with-pred))
+       (throw e)))))
 
 (defn stop-system
   "Recursively stops components in the system, in reverse dependency
@@ -168,9 +200,9 @@
   in the system specifying the components to stop, defaults to all
   keys in the system."
   ([system]
-     (stop-system system (keys system)))
+   (stop-system system (keys system)))
   ([system component-keys]
-     (update-system-reverse system component-keys #'stop)))
+   (update-system-reverse system component-keys stop-with-pred)))
 
 (defrecord SystemMap []
   Lifecycle


### PR DESCRIPTION
Wanted to get others thoughts on this. This is a problem I'm running into repeatedly when developing in the repl and I think this might be helpful to others as well. 

```clojure

;; CHANGES:

;; Sometimes during development an exception will be thrown during system start
;; for many reasons (a reliant service not being started, bugs when changing
;; start/stop implementations), and this essentially ruins the restart capability
;; of the system in certain scenarios (when we bind to outside ports, etc).
;; Since an exception is thrown, we don't keep a reference to the partially started
;; system and therefore can not stop the components that did successfully start
;; before the exception was thrown.

;; This commit attempts to teardown the started components in system if an 
;; exception is thrown during system start.

;; This also adds a nice predicate feature for inspecting whether or not a given
;; component is `started` or `stopped?` if they've been started within the
;; context of a system. This allows us to teardown only the components that had
;; actually been started rather than every component in the system.

(defrecord component-a []
  Lifecycle
  (start [this]
    (println "component-a started")
    this)
  (stop [this]
    (println "component-a stopped")
    this))

(defrecord component-b []
  Lifecycle
  (start [this]
    (throw (Exception. "Component not started. Shit broke!"))
    (println "component-b started")
    this)
  (stop [this]
    (println "component-b stopped")
    this))

(defrecord component-c []
  Lifecycle
  (start [this]
    (println "component-c started")
    this)
  (stop [this]
    (println "component-c stopped")
    this))

(def broken-system
  (system-map
   :component-a(map->component-a {})
   :component-b (using
                 (map->component-b {})
                 [:component-a])))

;; TEARDOWN ON EXCEPTION DURING START
;; (alter-var-root #'broken-system start-system)
;; =>
;; component-a started
;; component-a stopped
;; Exception Component not started. Shit broke!  com.stuartsierra.component.component-b (component.cljc:299)

;; PREDICATE FUNCTION
;; (map (fn [[k v]] (started? v)) broken-system)
;; => (false false)
;; (map (fn [[k v]] (stopped? v)) broken-system)
;; => (true true)

(def working-system
  (system-map
   :component-a(map->component-a {})
   :component-c (using
                 (map->component-c {})
                 [:component-a])))

;; SUCCESSFUL START
;; (alter-var-root #'working-system start-system)
;; =>
;; component-a started
;; component-c started

;; PREDICATE FUNCTION
;; (map (fn [[k v]] (started? v)) working-system)
;; => (true true)
;; (map (fn [[k v]] (stopped? v)) working-system)
;; => (false false)
```