### PR TITLE
[proposal] Shorthand dependency syntax

### DIFF
--- a/src/com/stuartsierra/component.cljc
+++ b/src/com/stuartsierra/component.cljc
@@ -32,7 +32,11 @@
   provided by its containing system. Values in the map are the keys in
   the system at which those components may be found. Alternatively, if
   the keys are the same in both the component and its enclosing
-  system, they may be specified as a vector of keys."
+  system, they may be specified as a vector of keys.
+  Shorthand syntax is supported to allow for aliasing only selected dependencies.
+  Thus the following are equivalent:
+  {:a :a :b :c}
+  [:a {:b :c}]"
   [component dependencies]
   (vary-meta
    component update-in [::dependencies] (fnil merge {})
@@ -40,7 +44,11 @@
     (map? dependencies)
       dependencies
     (vector? dependencies)
-      (into {} (map (fn [x] [x x]) dependencies))
+      (into {} (map (fn [x]
+                      (if (map? x)
+                        (vec (flatten (seq x)))
+                        [x x]))
+                    dependencies))
     :else
       (throw (ex-info "Dependencies must be a map or vector"
                       {:reason ::invalid-dependencies

--- a/test/com/stuartsierra/component_test.clj
+++ b/test/com/stuartsierra/component_test.clj
@@ -267,6 +267,19 @@
         system (component/system-using system dependency-map)]
     (assert-increments (increment-all-components system))))
 
+(deftest t-system-using-shorthand
+  (let [dependency-map {:b [:a]
+                        :c [:a :b]
+                        :d [:a {:b :b}]
+                        :e [:b :c :d]}
+        system {:a {:n 10}
+                :b {:n 20}
+                :c {:n 30}
+                :d {:n 40}
+                :e {:n 50}}
+        system (component/system-using system dependency-map)]
+    (assert-increments (increment-all-components system))))
+
 (defrecord ComponentWithoutLifecycle [state])
 
 (deftest component-without-lifecycle


### PR DESCRIPTION
This allows dependencies to be specified using a shorter syntax,
useful when most of dependencies are not aliased.

Makes the following:

```clojure
(component/using
  (queue/create config)
  {:connection :connection
  :statsd :statsd
  :monitoring :background-queue/monitoring })
```

To be written as:

```clojure
(component/using
  (queue/create config)
  [:connection :statsd {:monitoring :background-queue/monitoring }])
```

Component is great for structuring applications. We've adopted it in ~20 different services written in Clojure and it's been super helpful so far, not only for managing their runtime state but also code organization. 
One thing we found is that for more verbose components, listing dependencies tends to be really verbose in situations where each component needs a unique dependency. 