### PR TITLE
Add :extend-via-metadata to Lifecycle

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,5 +5,10 @@
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[com.stuartsierra/dependency "0.2.0"]
                  [org.clojure/clojure "1.7.0"]]
+  :aliases {"test-all" ["with-profile" "+1.7:+1.8:+1.9:+1.10" "test"]}
   :profiles {:dev {:dependencies [[org.clojure/tools.namespace "0.3.0-alpha1"]]
-                   :source-paths ["dev"]}})
+                   :source-paths ["dev"]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.9 {:dependencies [[org.clojure/clojure "1.9.0"]]}
+             :1.10 {:dependencies [[org.clojure/clojure "1.10.0"]]}})

--- a/src/com/stuartsierra/component.cljc
+++ b/src/com/stuartsierra/component.cljc
@@ -3,6 +3,7 @@
             [com.stuartsierra.component.platform :as platform]))
 
 (defprotocol Lifecycle
+  :extend-via-metadata true
   (start [component]
     "Begins operation of this component. Synchronous, does not return
   until the component is started. Returns an updated version of this


### PR DESCRIPTION
Hi @stuartsierra , I couldn't find your email anywhere otherwise I would have asked about this, per CONTRIBUTING.md 

Here is the 1 line backward compatible change required for the `Lifecycle` protocol to use Clojure 1.10's `:extend-via-metadata`.

I wrote a single test to illustrate the metadata extension style component working but will happily write more if you're interested in them.

I also included an alias to the `project.clj` to confirm it works with all previously supported versions of Clojure.

I hope you find this helpful,
Joe