### PR TITLE
Implement Closeable on SystemMap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,25 @@
 # Component Change Log
 
 
+## 1.2.x series
+
+### Version [1.2.0] released on October 25, 2025
+
+  * Add implementation of `java.io.Closeable` on `SystemMap`,
+    so `.close` on a system calls `component/stop`.
+    See [#76].
+
+    This allows use of [with-open](https://clojure.github.io/clojure/clojure.core-api.html#clojure.core/with-open)
+    on systems, for example `(with-open [system (start system)] ...)`
+    in tests.
+
+    Fulfulls a similar purpose as the various `with-*` macros
+    proposed in [#6], [#7], and elsewhere.
+    Also inspired by a conversation with [Ian Fernandez](https://github.com/ianffcs)
+    at [Clojure South 2025](https://clojure-south.com/).
+
+
+
 ## 1.1.x series
 
 ### Version [1.1.0] released on February 26, 2022
@@ -119,6 +138,7 @@
 ### Version [0.1.0] released on October 28, 2013
 
 
+[1.2.0]: https://github.com/stuartsierra/component/tree/component-1.2.0
 [1.1.0]: https://github.com/stuartsierra/component/tree/component-1.1.0
 [1.0.0]: https://github.com/stuartsierra/component/tree/component-1.0.0
 [0.4.0]: https://github.com/stuartsierra/component/tree/component-0.4.0
@@ -136,6 +156,8 @@
 [commit 7824f551]: https://github.com/stuartsierra/component/commit/7824f55129337c775a776daf6286fd43b8911b38
 [commit 5af4ad06]: https://github.com/stuartsierra/component/commit/5af4ad06fdc3ff3240573ae9394da92d8cf90c7e
 
+[#6]: https://github.com/stuartsierra/component/issues/6
+[#7]: https://github.com/stuartsierra/component/issues/7
 [#9]: https://github.com/stuartsierra/component/issues/9
 [#17]: https://github.com/stuartsierra/component/issues/17
 [#40]: https://github.com/stuartsierra/component/issues/40
@@ -143,6 +165,7 @@
 [#63]: https://github.com/stuartsierra/component/issues/63
 [#65]: https://github.com/stuartsierra/component/issues/65
 [#69]: https://github.com/stuartsierra/component/issues/69
+[#76]: https://github.com/stuartsierra/component/pull/76
 
 [dependency]: https://github.com/stuartsierra/dependency
 [tools.namespace]: https://github.com/clojure/tools.namespace

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ See the [video from Clojure/West 2014](https://www.youtube.com/watch?v=13cmHf_kt
 
 * I publish releases to [Clojars]
 
-* Latest stable release is [1.1.0](https://github.com/stuartsierra/component/tree/component-1.1.0)
+* Latest stable release is [1.2.0](https://github.com/stuartsierra/component/tree/component-1.2.0)
 
 * [All releases](https://clojars.org/com.stuartsierra/component)
 
@@ -22,18 +22,18 @@ See the [video from Clojure/West 2014](https://www.youtube.com/watch?v=13cmHf_kt
 
 [Leiningen] dependency information:
 
-    [com.stuartsierra/component "1.1.0"]
+    [com.stuartsierra/component "1.2.0"]
 
 [deps.edn] dependency information:
 
-    com.stuartsierra/component {:mvn/version "1.1.0"}
+    com.stuartsierra/component {:mvn/version "1.2.0"}
 
 [Maven] dependency information:
 
     <dependency>
       <groupId>com.stuartsierra</groupId>
       <artifactId>component</artifactId>
-      <version>1.1.0</version>
+      <version>1.2.0</version>
     </dependency>
 
 [Clojars]: http://clojars.org/

--- a/src/com/stuartsierra/component.cljc
+++ b/src/com/stuartsierra/component.cljc
@@ -181,9 +181,9 @@
     (start-system system))
   (stop [system]
     (stop-system system))
-  java.lang.AutoCloseable
-  (close [system]
-    (stop system)))
+  #?@(:clj [java.io.Closeable
+            (close [system]
+                   (stop system))]))
 
 #?(:clj
    (defmethod clojure.core/print-method SystemMap

--- a/src/com/stuartsierra/component.cljc
+++ b/src/com/stuartsierra/component.cljc
@@ -205,7 +205,7 @@
   'read'. To disable this behavior and print system maps like normal
   records, call
   (remove-method clojure.core/print-method com.stuartsierra.component.SystemMap)"
-  [& keyvals]
+  ^com.stuartsierra.component.SystemMap [& keyvals]
   ;; array-map doesn't check argument length (CLJ-1319)
   (when-not (even? (count keyvals))
     (throw (platform/argument-error

--- a/src/com/stuartsierra/component.cljc
+++ b/src/com/stuartsierra/component.cljc
@@ -205,7 +205,7 @@
   'read'. To disable this behavior and print system maps like normal
   records, call
   (remove-method clojure.core/print-method com.stuartsierra.component.SystemMap)"
-  ^com.stuartsierra.component.SystemMap [& keyvals]
+  [& keyvals]
   ;; array-map doesn't check argument length (CLJ-1319)
   (when-not (even? (count keyvals))
     (throw (platform/argument-error

--- a/src/com/stuartsierra/component.cljc
+++ b/src/com/stuartsierra/component.cljc
@@ -180,7 +180,10 @@
   (start [system]
     (start-system system))
   (stop [system]
-    (stop-system system)))
+    (stop-system system))
+  java.lang.AutoCloseable
+  (close [system]
+    (stop system)))
 
 #?(:clj
    (defmethod clojure.core/print-method SystemMap

--- a/test/com/stuartsierra/closeable_test.clj
+++ b/test/com/stuartsierra/closeable_test.clj
@@ -1,0 +1,35 @@
+(ns com.stuartsierra.closeable-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [com.stuartsierra.component :as component]))
+
+;; Compiling these tests should not generate reflection warnings
+(set! *warn-on-reflection* true)
+
+(defrecord TestComponent [state]
+  component/Lifecycle
+  (start [this]
+    (reset! state :started)
+    this)
+  (stop [this]
+    (reset! state :stopped)
+    this))
+
+(deftest t-closeable
+  (testing "SystemMap can be stopped via java.io.Closeable"
+    (let [state (atom nil)
+          test-component (->TestComponent state)
+          system (component/system-map :test test-component)]
+      (with-open [^java.io.Closeable system (component/start system)]
+        (is (instance? java.io.Closeable system))
+        (is (= :started @state)))
+      (is (= :stopped @state)))))
+
+(deftest t-autocloseable
+  (testing "SystemMap can be stopped via java.lang.AutoCloseable"
+    (let [state (atom nil)
+          test-component (->TestComponent state)
+          system (component/system-map :test test-component)]
+      (with-open [^java.lang.AutoCloseable system (component/start system)]
+        (is (instance? java.lang.AutoCloseable system))
+        (is (= :started @state)))
+      (is (= :stopped @state)))))


### PR DESCRIPTION
This adds an implementation for `java.io.Closeable` on `SystemMap` that calls `component/stop`.

This allows SystemMaps to be used in the `with-open` macro, for example in a test:

```clojure
(deftest ...
  (with-open [system (component/start (component/system-map ...))]
    ... test body ...))
```

This allows Clojure's built-in `with-open` to be used instead of a custom "with-*" macro as proposed in #6 and #7.

Inspired by a conversation at [Clojure South 2025](https://clojure-south.com/) with [Ian Fernandez](https://github.com/ianffcs).