### PR TITLE
Make 'system-map' work with k/v pairs or a map

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,4 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[com.stuartsierra/dependency "1.0.0"]
-                 [org.clojure/clojure "1.7.0" :scope "provided"]])
+                 [org.clojure/clojure "1.11.0" :scope "provided"]])

--- a/src/com/stuartsierra/component.cljc
+++ b/src/com/stuartsierra/component.cljc
@@ -196,7 +196,7 @@
        (-write writer "#<SystemMap>"))))
 
 (defn system-map
-  "Returns a system constructed of key/value pairs. The system has
+  "Returns a system constructed of key/value pairs or a map. The system has
   default implementations of the Lifecycle 'start' and 'stop' methods
   which recursively start/stop all components in the system.
 
@@ -205,12 +205,8 @@
   'read'. To disable this behavior and print system maps like normal
   records, call
   (remove-method clojure.core/print-method com.stuartsierra.component.SystemMap)"
-  [& keyvals]
-  ;; array-map doesn't check argument length (CLJ-1319)
-  (when-not (even? (count keyvals))
-    (throw (platform/argument-error
-            "system-map requires an even number of arguments")))
-  (map->SystemMap (apply array-map keyvals)))
+  [& {:as sys-map}]
+  (map->SystemMap sys-map))
 
 (defn subsystem
   "Returns a system containing only components associated with the keys

--- a/test/com/stuartsierra/component_test.clj
+++ b/test/com/stuartsierra/component_test.clj
@@ -228,6 +228,14 @@
   (let [system (component/start (system-2))]
     (is (started? (get-in system [:beta :one :d :my-c])))))
 
+
+(deftest map->system
+  (let [system (component/start (component/system-map {:a (component-a)
+                                                       :b (component-b)}))]
+    (is (started? (get-in system [:a])))
+    (is (started? (get-in system [:b])))))
+
+
 (defn increment-all-components [system]
   (component/update-system
    system (keys system) update-in [:n] inc))


### PR DESCRIPTION
This small change makes `system-map` work with both key/value pairs and passing the system as a map. A lot of the framework-ish code that I wrote over the years tends to compose systems out of maps, so I never found the use for `system-map` as is, and instead always used `map->SystemMap`. With this change we can do both and keep the public facing API somewhat cleaner.

Only downside is that this makes Component require Clojure 1.11 and up as that's [when support for kw-args as map](https://clojure.org/news/2021/03/18/apis-serving-people-and-programs) was added.